### PR TITLE
Point schema_input.json $id at the master branch

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://raw.githubusercontent.com/nf-core/longraredisease/dev/assets/schema_input.json",
+    "$id": "https://raw.githubusercontent.com/nf-core/longraredisease/master/assets/schema_input.json",
     "title": "nf-core/longraredisease pipeline - params.input schema",
     "description": "Schema for the file provided with params.input",
     "type": "array",


### PR DESCRIPTION
Apply @maxulysse review suggestion on PR #55: the params.input schema $id should reference the master branch, not dev.

<!--
# nf-core/longraredisease pull request

Many thanks for contributing to nf-core/longraredisease!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/longraredisease/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/longraredisease/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/longraredisease _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
